### PR TITLE
init: Fix systemd service

### DIFF
--- a/init/fancontrold.service.cmakein
+++ b/init/fancontrold.service.cmakein
@@ -6,7 +6,7 @@ Description=FANCONTROL Daemon
 ConditionPathExists=/sys/bus/iio /sys/class/hwmon
 
 [Service]
-ExecStart=@iCMAKE_INSTALL_FULL_SBINDIR@/@BIN@
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/@BIN@
 KillMode=process
 Restart=on-failure
 


### PR DESCRIPTION
Fix a typo in the systemd service preventing the path to the daemon to
be given correctly.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>