### PR TITLE
update to libiio1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # Licensed under the ADI BSD
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(fancontrold C)
 
 set(BIN fancontrold)
@@ -13,12 +13,10 @@ include(GNUInstallDirs)
 add_compile_options(-O2 -Wall -Wextra -Werror)
 
 find_library(LIBIIO_LIBRARIES iio)
-find_path(LIBIIO_INCLUDE_DIRS iio.h)
-
-include_directories(
-	${LIBIIO_INCLUDE_DIRS})
+find_path(LIBIIO_INCLUDE_DIRS iio/iio.h)
 
 add_executable(${BIN} ${SRC})
+target_include_directories(${BIN} PRIVATE ${LIBIIO_INCLUDE_DIRS})
 target_link_libraries(${BIN} ${LIBIIO_LIBRARIES})
 
 install(TARGETS ${BIN}

--- a/fancontrold.c
+++ b/fancontrold.c
@@ -19,7 +19,7 @@
 #include <sys/reboot.h>
 #include <dirent.h>
 #include <syslog.h>
-#include <iio.h>
+#include <iio/iio.h>
 
 #define emerg(fmt, ...) \
 	syslog(LOG_EMERG, \
@@ -202,7 +202,7 @@ static long monitor_iio_dev_attr_get(const struct monitor_iio_dev *dev)
 	long temp;
 	char *endptr;
 
-	cnt = iio_channel_attr_read(dev->ch, dev->attr, buf, sizeof(buf));
+	cnt = iio_channel_attr_read_raw(dev->ch, dev->attr, buf, sizeof(buf));
 	if (cnt < 0) {
 		error("Failed to read attr: %s\n", strerror(-cnt));
 		return 0;
@@ -474,7 +474,7 @@ static int iio_devices_scan(void)
 	uint32_t cnt;
 	int ret = 0;
 
-	fan_monitor.ctx = iio_create_default_context();
+	fan_monitor.ctx = iio_create_context(NULL, NULL);
 	if (!fan_monitor.ctx) {
 		error("Failed to create iio context\n");
 		return -1;


### PR DESCRIPTION
Make sure the daemon builds with vesion 1.0.

@pcercuei, this is fairly simple but it would still be nice if you can sanity check the api changes (this is only compile tested). 